### PR TITLE
fix: create service-account only when needed

### DIFF
--- a/humanitec-resource-defs/k8s/service-account/main.tf
+++ b/humanitec-resource-defs/k8s/service-account/main.tf
@@ -23,7 +23,9 @@ serviceaccount.yaml:
     metadata:
       name: $${resources.gcp-service-account.outputs.k8s_service_account_name}
       annotations:
+        {{- if "$${resources.gcp-service-account.outputs.email}" }}
         iam.gke.io/gcp-service-account: $${resources.gcp-service-account.outputs.email}
+        {{- end }}
         context: {{trimPrefix "modules." "$${context.res.id}"}}
         res: $${context.res.id}
         app: $${context.app.id}

--- a/modules/gcp-service-account/workload/bindings.tf
+++ b/modules/gcp-service-account/workload/bindings.tf
@@ -10,5 +10,5 @@ resource "google_storage_bucket_iam_member" "main" {
 
   bucket = each.value["bucket"]
   role   = each.value["role"]
-  member = "serviceAccount:${google_service_account.main.email}"
+  member = "serviceAccount:${google_service_account.main[0].email}"
 }

--- a/modules/gcp-service-account/workload/main.tf
+++ b/modules/gcp-service-account/workload/main.tf
@@ -1,8 +1,11 @@
 locals {
   k8s_service_account_name = "${var.app_id}-${var.env_id}-${trimprefix(var.res_id, "modules.")}"
+  account_required         = length(var.bindings) + length(var.roles) > 0
 }
 
 resource "google_service_account" "main" {
+  count = local.account_required ? 1 : 0
+
   display_name = "${var.prefix}workload service account"
   account_id   = "${var.prefix}workload"
 }
@@ -12,11 +15,13 @@ resource "google_project_iam_member" "role" {
 
   project = var.project
   role    = each.key
-  member  = "serviceAccount:${google_service_account.main.email}"
+  member  = "serviceAccount:${google_service_account.main[0].email}"
 }
 
 resource "google_service_account_iam_member" "workload_identity_k8s_service_account" {
-  service_account_id = google_service_account.main.name
+  count = local.account_required ? 1 : 0
+
+  service_account_id = google_service_account.main[0].name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project}.svc.id.goog[${var.namespace}/${local.k8s_service_account_name}]"
 }

--- a/modules/gcp-service-account/workload/outputs.tf
+++ b/modules/gcp-service-account/workload/outputs.tf
@@ -1,5 +1,5 @@
 output "email" {
-  value = google_service_account.main.email
+  value = local.account_required ? google_service_account.main[0].email : ""
 }
 
 output "k8s_service_account_name" {


### PR DESCRIPTION
Create the `gcp-service-account` only when the workload has policies.