### PR TITLE
feat: cloudsql

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The following resources are included:
 
 * [dns/basic](./humanitec-resource-defs/dns/basic): GCP Cloud DNS `dns` resource.
 * [gcs/basic](./humanitec-resource-defs/gcs/basic): A basic cloud storage bucket.
+* [mysql/basic](./humanitec-resource-defs/mysql/basic): A `mysql` resource using GCP CloudSQL.
+* [postgres/basic](./humanitec-resource-defs/postgres/basic): A `postgres` resource using GCP CloudSQL.
 * [redis/basic](./humanitec-resource-defs/redis/basic): GCP Memorystore `redis` resource.
 
 The `humanitec-resource-defs` directory includes the respective resource definitions.

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -1,0 +1,59 @@
+# Example: mysql resource based on GCP CloudSQL
+
+This example configures a [mysql](https://developer.humanitec.com/platform-orchestrator/reference/resource-types/#mysql) Resource Definition using GCP CloudSQL.
+
+The created Resource Definition can be used in your Score file using:
+
+```yaml
+resources:
+  ...
+  db:
+    type: mysql
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| google | ~> 5.17 |
+| humanitec | ~> 0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | ~> 5.17 |
+| humanitec | ~> 0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| mysql | ../../humanitec-resource-defs/mysql/basic | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_global_address.private_ip_address](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_project_service.servicenetworking](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_service_networking_connection.private_vpc_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
+| [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_definition_criteria.mysql](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [google_compute_network.network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| credentials | n/a | `string` | n/a | yes |
+| private\_network | The VPC network from which the Cloud SQL instance is accessible for private IP. | `string` | n/a | yes |
+| project | n/a | `string` | n/a | yes |
+| region | n/a | `string` | n/a | yes |
+| name | Name of the example application | `string` | `"hum-rp-mysql-example"` | no |
+| prefix | Prefix of the created resources | `string` | `"hum-rp-mysql-ex-"` | no |
+| resource\_packs\_gcp\_rev | n/a | `string` | `"ref/heads/main"` | no |
+| resource\_packs\_gcp\_url | n/a | `string` | `"https://github.com/humanitec-architecture/resource-packs-gcp.git"` | no |
+<!-- END_TF_DOCS -->

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -1,0 +1,52 @@
+resource "humanitec_application" "example" {
+  id   = var.name
+  name = var.name
+}
+
+data "google_compute_network" "network" {
+  name = var.private_network
+}
+
+resource "google_project_service" "servicenetworking" {
+  service            = "servicenetworking.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_compute_global_address" "private_ip_address" {
+  name          = "${var.prefix}private-ip-address"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = data.google_compute_network.network.id
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = data.google_compute_network.network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
+
+  depends_on = [google_project_service.servicenetworking]
+}
+
+module "mysql" {
+  source = "../../humanitec-resource-defs/mysql/basic"
+
+  prefix                 = var.prefix
+  resource_packs_gcp_rev = var.resource_packs_gcp_rev
+  resource_packs_gcp_url = var.resource_packs_gcp_url
+  project                = var.project
+  region                 = var.region
+  credentials            = var.credentials
+
+  database_version = "MYSQL_8_0"
+  tier             = "db-f1-micro"
+  private_network  = data.google_compute_network.network.id
+
+  depends_on = [google_service_networking_connection.private_vpc_connection]
+}
+
+resource "humanitec_resource_definition_criteria" "mysql" {
+  resource_definition_id = module.mysql.id
+  app_id                 = humanitec_application.example.id
+  force_delete           = true
+}

--- a/examples/mysql/providers.tf
+++ b/examples/mysql/providers.tf
@@ -4,10 +4,16 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 5.17"
     }
+    humanitec = {
+      source  = "humanitec/humanitec"
+      version = "~> 0"
+    }
   }
 
   required_version = ">= 1.3.0"
 }
+
+provider "humanitec" {}
 
 provider "google" {
   project     = var.project
@@ -15,10 +21,7 @@ provider "google" {
   credentials = var.credentials
 
   default_labels = {
-    "humanitec"  = "true"
-    "hum-app"    = var.app_id
-    "hum-env"    = var.env_id
-    "hum-res"    = replace(var.res_id, ".", "-")
-    "managed-by" = "terraform"
+    "managed_by" = "terraform"
+    "source"     = "github.com/humanitec-architecture/resource-pack-gcp"
   }
 }

--- a/examples/mysql/terraform.tfvars.example
+++ b/examples/mysql/terraform.tfvars.example
@@ -1,0 +1,15 @@
+credentials = ""
+
+# Name of the example application
+name = "hum-rp-mysql-example"
+
+# Prefix of the created resources
+prefix = "hum-rp-mysql-ex-"
+
+# The VPC network from which the Cloud SQL instance is accessible for private IP.
+private_network = ""
+
+project                = ""
+region                 = ""
+resource_packs_gcp_rev = "ref/heads/main"
+resource_packs_gcp_url = "https://github.com/humanitec-architecture/resource-packs-gcp.git"

--- a/examples/mysql/variables.tf
+++ b/examples/mysql/variables.tf
@@ -1,0 +1,38 @@
+variable "name" {
+  description = "Name of the example application"
+  type        = string
+  default     = "hum-rp-mysql-example"
+}
+
+variable "resource_packs_gcp_rev" {
+  type    = string
+  default = "ref/heads/main"
+}
+
+variable "resource_packs_gcp_url" {
+  type    = string
+  default = "https://github.com/humanitec-architecture/resource-packs-gcp.git"
+}
+
+variable "prefix" {
+  description = "Prefix of the created resources"
+  type        = string
+  default     = "hum-rp-mysql-ex-"
+}
+
+variable "project" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "credentials" {
+  type = string
+}
+
+variable "private_network" {
+  type        = string
+  description = "The VPC network from which the Cloud SQL instance is accessible for private IP."
+}

--- a/examples/postgres/README.md
+++ b/examples/postgres/README.md
@@ -1,0 +1,59 @@
+# Example: postgres resource based on GCP CloudSQL
+
+This example configures a [postgres](https://developer.humanitec.com/platform-orchestrator/reference/resource-types/#postgres) Resource Definition using GCP CloudSQL.
+
+The created Resource Definition can be used in your Score file using:
+
+```yaml
+resources:
+  ...
+  db:
+    type: postgres
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| google | ~> 5.17 |
+| humanitec | ~> 0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | ~> 5.17 |
+| humanitec | ~> 0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| postgres | ../../humanitec-resource-defs/postgres/basic | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_global_address.private_ip_address](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_project_service.servicenetworking](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_service_networking_connection.private_vpc_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
+| [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_definition_criteria.postgres](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [google_compute_network.network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| credentials | n/a | `string` | n/a | yes |
+| private\_network | The VPC network from which the Cloud SQL instance is accessible for private IP. | `string` | n/a | yes |
+| project | n/a | `string` | n/a | yes |
+| region | n/a | `string` | n/a | yes |
+| name | Name of the example application | `string` | `"hum-rp-postgres-example"` | no |
+| prefix | Prefix of the created resources | `string` | `"hum-rp-postgres-ex-"` | no |
+| resource\_packs\_gcp\_rev | n/a | `string` | `"ref/heads/main"` | no |
+| resource\_packs\_gcp\_url | n/a | `string` | `"https://github.com/humanitec-architecture/resource-packs-gcp.git"` | no |
+<!-- END_TF_DOCS -->

--- a/examples/postgres/main.tf
+++ b/examples/postgres/main.tf
@@ -1,0 +1,52 @@
+resource "humanitec_application" "example" {
+  id   = var.name
+  name = var.name
+}
+
+data "google_compute_network" "network" {
+  name = var.private_network
+}
+
+resource "google_project_service" "servicenetworking" {
+  service            = "servicenetworking.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_compute_global_address" "private_ip_address" {
+  name          = "${var.prefix}private-ip-address"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = data.google_compute_network.network.id
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = data.google_compute_network.network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
+
+  depends_on = [google_project_service.servicenetworking]
+}
+
+module "postgres" {
+  source = "../../humanitec-resource-defs/postgres/basic"
+
+  prefix                 = var.prefix
+  resource_packs_gcp_rev = var.resource_packs_gcp_rev
+  resource_packs_gcp_url = var.resource_packs_gcp_url
+  project                = var.project
+  region                 = var.region
+  credentials            = var.credentials
+
+  database_version = "POSTGRES_15"
+  tier             = "db-f1-micro"
+  private_network  = data.google_compute_network.network.id
+
+  depends_on = [google_service_networking_connection.private_vpc_connection]
+}
+
+resource "humanitec_resource_definition_criteria" "postgres" {
+  resource_definition_id = module.postgres.id
+  app_id                 = humanitec_application.example.id
+  force_delete           = true
+}

--- a/examples/postgres/providers.tf
+++ b/examples/postgres/providers.tf
@@ -4,10 +4,16 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 5.17"
     }
+    humanitec = {
+      source  = "humanitec/humanitec"
+      version = "~> 0"
+    }
   }
 
   required_version = ">= 1.3.0"
 }
+
+provider "humanitec" {}
 
 provider "google" {
   project     = var.project
@@ -15,10 +21,7 @@ provider "google" {
   credentials = var.credentials
 
   default_labels = {
-    "humanitec"  = "true"
-    "hum-app"    = var.app_id
-    "hum-env"    = var.env_id
-    "hum-res"    = replace(var.res_id, ".", "-")
-    "managed-by" = "terraform"
+    "managed_by" = "terraform"
+    "source"     = "github.com/humanitec-architecture/resource-pack-gcp"
   }
 }

--- a/examples/postgres/terraform.tfvars.example
+++ b/examples/postgres/terraform.tfvars.example
@@ -1,0 +1,15 @@
+credentials = ""
+
+# Name of the example application
+name = "hum-rp-postgres-example"
+
+# Prefix of the created resources
+prefix = "hum-rp-postgres-ex-"
+
+# The VPC network from which the Cloud SQL instance is accessible for private IP.
+private_network = ""
+
+project                = ""
+region                 = ""
+resource_packs_gcp_rev = "ref/heads/main"
+resource_packs_gcp_url = "https://github.com/humanitec-architecture/resource-packs-gcp.git"

--- a/examples/postgres/variables.tf
+++ b/examples/postgres/variables.tf
@@ -1,0 +1,38 @@
+variable "name" {
+  description = "Name of the example application"
+  type        = string
+  default     = "hum-rp-postgres-example"
+}
+
+variable "resource_packs_gcp_rev" {
+  type    = string
+  default = "ref/heads/main"
+}
+
+variable "resource_packs_gcp_url" {
+  type    = string
+  default = "https://github.com/humanitec-architecture/resource-packs-gcp.git"
+}
+
+variable "prefix" {
+  description = "Prefix of the created resources"
+  type        = string
+  default     = "hum-rp-postgres-ex-"
+}
+
+variable "project" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "credentials" {
+  type = string
+}
+
+variable "private_network" {
+  type        = string
+  description = "The VPC network from which the Cloud SQL instance is accessible for private IP."
+}

--- a/humanitec-resource-defs/mysql/basic/README.md
+++ b/humanitec-resource-defs/mysql/basic/README.md
@@ -1,0 +1,41 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| humanitec | ~> 0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| humanitec | ~> 0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [humanitec_resource_definition.main](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| credentials | n/a | `string` | n/a | yes |
+| database\_version | The MySQL, PostgreSQL or SQL Server version to use. | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
+| private\_network | The VPC network from which the Cloud SQL instance is accessible for private IP. | `string` | n/a | yes |
+| project | n/a | `string` | n/a | yes |
+| region | n/a | `string` | n/a | yes |
+| tier | The machine type to use. | `string` | n/a | yes |
+| name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
+| resource\_packs\_gcp\_rev | n/a | `string` | `"ref/heads/main"` | no |
+| resource\_packs\_gcp\_url | n/a | `string` | `"https://github.com/humanitec-architecture/resource-packs-gcp.git"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| id | n/a |
+<!-- END_TF_DOCS -->

--- a/humanitec-resource-defs/mysql/basic/main.tf
+++ b/humanitec-resource-defs/mysql/basic/main.tf
@@ -1,0 +1,38 @@
+resource "humanitec_resource_definition" "main" {
+  driver_type = "humanitec/terraform"
+  id          = "${var.prefix}cloudsql-mysql"
+  name        = "${var.prefix}cloudsql-mysql"
+  type        = "mysql"
+
+  driver_inputs = {
+    secrets_string = jsonencode({
+      variables = {
+        credentials = var.credentials
+      }
+
+    })
+
+    values_string = jsonencode({
+      source = {
+        path = "modules/cloudsql/basic"
+        rev  = var.resource_packs_gcp_rev
+        url  = var.resource_packs_gcp_url
+      }
+
+      variables = {
+        name    = var.name
+        project = var.project
+        region  = var.region
+        prefix  = var.prefix
+        app_id  = "$${context.app.id}"
+        env_id  = "$${context.env.id}"
+        res_id  = "$${context.res.id}"
+
+        database_version = var.database_version
+        tier             = var.tier
+        private_network  = var.private_network
+        port             = 3306
+      }
+    })
+  }
+}

--- a/humanitec-resource-defs/mysql/basic/outputs.tf
+++ b/humanitec-resource-defs/mysql/basic/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = humanitec_resource_definition.main.id
+}

--- a/humanitec-resource-defs/mysql/basic/providers.tf
+++ b/humanitec-resource-defs/mysql/basic/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    humanitec = {
+      source  = "humanitec/humanitec"
+      version = "~> 0"
+    }
+  }
+
+  required_version = ">= 1.3.0"
+}

--- a/humanitec-resource-defs/mysql/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/mysql/basic/terraform.tfvars.example
@@ -1,0 +1,21 @@
+credentials = ""
+
+# The MySQL, PostgreSQL or SQL Server version to use.
+database_version = ""
+
+# Resource name (can contain placeholders like ${context.app.id})
+name = ""
+
+# Prefix for all resources
+prefix = ""
+
+# The VPC network from which the Cloud SQL instance is accessible for private IP.
+private_network = ""
+
+project                = ""
+region                 = ""
+resource_packs_gcp_rev = "ref/heads/main"
+resource_packs_gcp_url = "https://github.com/humanitec-architecture/resource-packs-gcp.git"
+
+# The machine type to use.
+tier = ""

--- a/humanitec-resource-defs/mysql/basic/variables.tf
+++ b/humanitec-resource-defs/mysql/basic/variables.tf
@@ -1,0 +1,47 @@
+variable "prefix" {
+  description = "Prefix for all resources"
+  type        = string
+}
+
+variable "resource_packs_gcp_rev" {
+  type    = string
+  default = "ref/heads/main"
+}
+
+variable "resource_packs_gcp_url" {
+  type    = string
+  default = "https://github.com/humanitec-architecture/resource-packs-gcp.git"
+}
+
+variable "project" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "credentials" {
+  type = string
+}
+
+variable "name" {
+  type        = string
+  description = "Resource name (can contain placeholders like $${context.app.id})"
+  default     = ""
+}
+
+variable "database_version" {
+  type        = string
+  description = "The MySQL, PostgreSQL or SQL Server version to use."
+}
+
+variable "tier" {
+  type        = string
+  description = "The machine type to use."
+}
+
+variable "private_network" {
+  type        = string
+  description = "The VPC network from which the Cloud SQL instance is accessible for private IP."
+}

--- a/humanitec-resource-defs/postgres/basic/README.md
+++ b/humanitec-resource-defs/postgres/basic/README.md
@@ -1,0 +1,41 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| humanitec | ~> 0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| humanitec | ~> 0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [humanitec_resource_definition.main](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| credentials | n/a | `string` | n/a | yes |
+| database\_version | The MySQL, PostgreSQL or SQL Server version to use. | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
+| private\_network | The VPC network from which the Cloud SQL instance is accessible for private IP. | `string` | n/a | yes |
+| project | n/a | `string` | n/a | yes |
+| region | n/a | `string` | n/a | yes |
+| tier | The machine type to use. | `string` | n/a | yes |
+| name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
+| resource\_packs\_gcp\_rev | n/a | `string` | `"ref/heads/main"` | no |
+| resource\_packs\_gcp\_url | n/a | `string` | `"https://github.com/humanitec-architecture/resource-packs-gcp.git"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| id | n/a |
+<!-- END_TF_DOCS -->

--- a/humanitec-resource-defs/postgres/basic/main.tf
+++ b/humanitec-resource-defs/postgres/basic/main.tf
@@ -1,0 +1,38 @@
+resource "humanitec_resource_definition" "main" {
+  driver_type = "humanitec/terraform"
+  id          = "${var.prefix}cloudsql-postgres"
+  name        = "${var.prefix}cloudsql-postgres"
+  type        = "postgres"
+
+  driver_inputs = {
+    secrets_string = jsonencode({
+      variables = {
+        credentials = var.credentials
+      }
+
+    })
+
+    values_string = jsonencode({
+      source = {
+        path = "modules/cloudsql/basic"
+        rev  = var.resource_packs_gcp_rev
+        url  = var.resource_packs_gcp_url
+      }
+
+      variables = {
+        name    = var.name
+        project = var.project
+        region  = var.region
+        prefix  = var.prefix
+        app_id  = "$${context.app.id}"
+        env_id  = "$${context.env.id}"
+        res_id  = "$${context.res.id}"
+
+        database_version = var.database_version
+        tier             = var.tier
+        private_network  = var.private_network
+        port             = 5432
+      }
+    })
+  }
+}

--- a/humanitec-resource-defs/postgres/basic/outputs.tf
+++ b/humanitec-resource-defs/postgres/basic/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = humanitec_resource_definition.main.id
+}

--- a/humanitec-resource-defs/postgres/basic/providers.tf
+++ b/humanitec-resource-defs/postgres/basic/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    humanitec = {
+      source  = "humanitec/humanitec"
+      version = "~> 0"
+    }
+  }
+
+  required_version = ">= 1.3.0"
+}

--- a/humanitec-resource-defs/postgres/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/postgres/basic/terraform.tfvars.example
@@ -1,0 +1,21 @@
+credentials = ""
+
+# The MySQL, PostgreSQL or SQL Server version to use.
+database_version = ""
+
+# Resource name (can contain placeholders like ${context.app.id})
+name = ""
+
+# Prefix for all resources
+prefix = ""
+
+# The VPC network from which the Cloud SQL instance is accessible for private IP.
+private_network = ""
+
+project                = ""
+region                 = ""
+resource_packs_gcp_rev = "ref/heads/main"
+resource_packs_gcp_url = "https://github.com/humanitec-architecture/resource-packs-gcp.git"
+
+# The machine type to use.
+tier = ""

--- a/humanitec-resource-defs/postgres/basic/variables.tf
+++ b/humanitec-resource-defs/postgres/basic/variables.tf
@@ -1,0 +1,47 @@
+variable "prefix" {
+  description = "Prefix for all resources"
+  type        = string
+}
+
+variable "resource_packs_gcp_rev" {
+  type    = string
+  default = "ref/heads/main"
+}
+
+variable "resource_packs_gcp_url" {
+  type    = string
+  default = "https://github.com/humanitec-architecture/resource-packs-gcp.git"
+}
+
+variable "project" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "credentials" {
+  type = string
+}
+
+variable "name" {
+  type        = string
+  description = "Resource name (can contain placeholders like $${context.app.id})"
+  default     = ""
+}
+
+variable "database_version" {
+  type        = string
+  description = "The MySQL, PostgreSQL or SQL Server version to use."
+}
+
+variable "tier" {
+  type        = string
+  description = "The machine type to use."
+}
+
+variable "private_network" {
+  type        = string
+  description = "The VPC network from which the Cloud SQL instance is accessible for private IP."
+}

--- a/modules/cloudsql/basic/README.md
+++ b/modules/cloudsql/basic/README.md
@@ -1,0 +1,52 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| google | ~> 5.17 |
+| random | ~> 3.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | ~> 5.17 |
+| random | ~> 3.5 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_sql_database.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
+| [google_sql_database_instance.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
+| [google_sql_user.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
+| [random_password.password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| app\_id | n/a | `string` | n/a | yes |
+| credentials | n/a | `any` | n/a | yes |
+| database\_version | The MySQL, PostgreSQL or SQL Server version to use. | `string` | n/a | yes |
+| env\_id | n/a | `string` | n/a | yes |
+| port | The port for the database (needs to match the database type) | `number` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
+| private\_network | The VPC network from which the Cloud SQL instance is accessible for private IP. | `string` | n/a | yes |
+| project | n/a | `string` | n/a | yes |
+| region | n/a | `string` | n/a | yes |
+| res\_id | n/a | `string` | n/a | yes |
+| tier | The machine type to use. | `string` | n/a | yes |
+| name | Resource name | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| host | The IP address the instance is available on. |
+| name | The name of the database that the workload should connect to. |
+| password | The password for the user. |
+| port | The port on the host that the instance is available on. |
+| username | The user that the workload should use to connect to the database. |
+<!-- END_TF_DOCS -->

--- a/modules/cloudsql/basic/main.tf
+++ b/modules/cloudsql/basic/main.tf
@@ -1,0 +1,43 @@
+locals {
+  # Name restrictions https://cloud.google.com/sql/docs/postgres/instance-settings
+  # The total length of project-ID:instance-ID must be 98 characters or less.
+  default_name = substr("${var.prefix}${var.app_id}-${var.env_id}-${replace(var.res_id, ".", "-")}", 0, 98 - length(var.project))
+
+  default_database = "main"
+  default_username = "main"
+}
+
+resource "google_sql_database_instance" "main" {
+  name = coalesce(var.name, local.default_name)
+
+  database_version = var.database_version
+
+  # Disable deletion protection as otherwise Humanitec can't delete the database
+  deletion_protection = false
+
+  settings {
+    tier = var.tier
+
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = var.private_network
+      enable_private_path_for_google_cloud_services = true
+    }
+  }
+}
+
+resource "random_password" "password" {
+  length  = 16
+  special = false
+}
+
+resource "google_sql_database" "main" {
+  name     = local.default_database
+  instance = google_sql_database_instance.main.name
+}
+
+resource "google_sql_user" "main" {
+  name     = local.default_username
+  instance = google_sql_database_instance.main.name
+  password = random_password.password.result
+}

--- a/modules/cloudsql/basic/outputs.tf
+++ b/modules/cloudsql/basic/outputs.tf
@@ -1,0 +1,27 @@
+# See https://developer.humanitec.com/platform-orchestrator/reference/resource-types/#postgres for expected outputs
+
+output "host" {
+  description = "The IP address the instance is available on."
+  value       = google_sql_database_instance.main.private_ip_address
+}
+
+output "name" {
+  description = "The name of the database that the workload should connect to."
+  value       = google_sql_database.main.name
+}
+
+output "port" {
+  description = "The port on the host that the instance is available on."
+  value       = var.port
+}
+
+output "username" {
+  description = "The user that the workload should use to connect to the database."
+  value       = google_sql_user.main.name
+}
+
+output "password" {
+  description = "The password for the user."
+  value       = google_sql_user.main.password
+  sensitive   = true
+}

--- a/modules/cloudsql/basic/providers.tf
+++ b/modules/cloudsql/basic/providers.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 5.17"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
   }
 
   required_version = ">= 1.3.0"

--- a/modules/cloudsql/basic/terraform.tfvars.example
+++ b/modules/cloudsql/basic/terraform.tfvars.example
@@ -1,0 +1,26 @@
+app_id      = ""
+credentials = ""
+
+# The MySQL, PostgreSQL or SQL Server version to use.
+database_version = ""
+
+env_id = ""
+
+# Resource name
+name = ""
+
+# The port for the database (needs to match the database type)
+port = ""
+
+# Prefix for all resources
+prefix = ""
+
+# The VPC network from which the Cloud SQL instance is accessible for private IP.
+private_network = ""
+
+project = ""
+region  = ""
+res_id  = ""
+
+# The machine type to use.
+tier = ""

--- a/modules/cloudsql/basic/variables.tf
+++ b/modules/cloudsql/basic/variables.tf
@@ -1,0 +1,54 @@
+variable "prefix" {
+  type        = string
+  description = "Prefix for all resources"
+}
+
+variable "project" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "credentials" {
+  type = any
+}
+
+variable "app_id" {
+  type = string
+}
+
+variable "env_id" {
+  type = string
+}
+
+variable "res_id" {
+  type = string
+}
+
+variable "name" {
+  type        = string
+  description = "Resource name"
+  default     = ""
+}
+
+variable "database_version" {
+  type        = string
+  description = "The MySQL, PostgreSQL or SQL Server version to use."
+}
+
+variable "tier" {
+  type        = string
+  description = "The machine type to use."
+}
+
+variable "private_network" {
+  type        = string
+  description = "The VPC network from which the Cloud SQL instance is accessible for private IP."
+}
+
+variable "port" {
+  type        = number
+  description = "The port for the database (needs to match the database type)"
+}

--- a/modules/dns/basic/README.md
+++ b/modules/dns/basic/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
-| google | ~> 5.10 |
+| google | ~> 5.17 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 5.10 |
+| google | ~> 5.17 |
 
 ## Resources
 

--- a/modules/gcp-service-account/workload/README.md
+++ b/modules/gcp-service-account/workload/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
-| google | ~> 5.1 |
+| google | ~> 5.17 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 5.1 |
+| google | ~> 5.17 |
 
 ## Resources
 

--- a/modules/gcp-service-account/workload/providers.tf
+++ b/modules/gcp-service-account/workload/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.1"
+      version = "~> 5.17"
     }
   }
 

--- a/modules/gcs/basic/README.md
+++ b/modules/gcs/basic/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
-| google | ~> 5.1 |
+| google | ~> 5.17 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 5.1 |
+| google | ~> 5.17 |
 
 ## Resources
 

--- a/modules/gcs/basic/providers.tf
+++ b/modules/gcs/basic/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.1"
+      version = "~> 5.17"
     }
   }
 

--- a/modules/redis/basic/README.md
+++ b/modules/redis/basic/README.md
@@ -4,19 +4,19 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
-| google | 5.10.0 |
+| google | ~> 5.17 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | 5.10.0 |
+| google | ~> 5.17 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [google_redis_instance.cache](https://registry.terraform.io/providers/hashicorp/google/5.10.0/docs/resources/redis_instance) | resource |
+| [google_redis_instance.cache](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance) | resource |
 
 ## Inputs
 

--- a/modules/redis/basic/providers.tf
+++ b/modules/redis/basic/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.10.0"
+      version = "~> 5.17"
     }
   }
 


### PR DESCRIPTION
Create `postgres` and `mysql` resources using GCP CloudSQL.

So far only a basic version without sidecar & iam-authentication, but I would like to merge it so we have something basic that we can iterate on.