### PR TITLE
feat: use resource account

### DIFF
--- a/examples/dns/README.md
+++ b/examples/dns/README.md
@@ -51,12 +51,14 @@ graph LR;
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
+| google | ~> 5.17 |
 | humanitec | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| google | ~> 5.17 |
 | humanitec | ~> 1.0 |
 
 ## Modules
@@ -69,14 +71,17 @@ graph LR;
 
 | Name | Type |
 |------|------|
+| [google_project_iam_member.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_key.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.dns_basic](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
 | managed\_zone | The name of the zone in which this record set will reside. | `string` | n/a | yes |
 | managed\_zone\_dns\_name | The DNS name of the managed zone. | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |

--- a/examples/dns/main.tf
+++ b/examples/dns/main.tf
@@ -1,3 +1,35 @@
+# GCP service account used by Humanitec to provision resources
+
+resource "google_service_account" "humanitec_provisioner" {
+  account_id  = var.name
+  description = "Account used by Humanitec to provision resources"
+}
+
+resource "google_project_iam_member" "humanitec_provisioner" {
+  project = var.project
+  role    = "roles/owner"
+  member  = "serviceAccount:${google_service_account.humanitec_provisioner.email}"
+}
+
+resource "google_service_account_key" "humanitec_provisioner" {
+  service_account_id = google_service_account.humanitec_provisioner.name
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "gcp"
+
+  credentials = base64decode(google_service_account_key.humanitec_provisioner.private_key)
+
+  depends_on = [
+    # Otherwise the account looses permissions before the resources are deleted
+    google_project_iam_member.humanitec_provisioner
+  ]
+}
+
+# Example application and resource definition criteria
+
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -12,10 +44,11 @@ module "dns_basic" {
 
   resource_packs_gcp_url = var.resource_packs_gcp_url
   resource_packs_gcp_rev = var.resource_packs_gcp_rev
+  append_logs_to_error   = true
+  driver_account         = humanitec_resource_account.humanitec_provisioner.id
 
-  project     = var.project
-  region      = var.region
-  credentials = var.credentials
+  project = var.project
+  region  = var.region
 
   managed_zone          = var.managed_zone
   managed_zone_dns_name = var.managed_zone_dns_name
@@ -24,4 +57,5 @@ module "dns_basic" {
 resource "humanitec_resource_definition_criteria" "dns_basic" {
   resource_definition_id = module.dns_basic.id
   app_id                 = humanitec_application.example.id
+  force_delete           = true
 }

--- a/examples/dns/providers.tf
+++ b/examples/dns/providers.tf
@@ -1,5 +1,9 @@
 terraform {
   required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.17"
+    }
     humanitec = {
       source  = "humanitec/humanitec"
       version = "~> 1.0"
@@ -10,3 +14,13 @@ terraform {
 }
 
 provider "humanitec" {}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+
+  default_labels = {
+    "managed_by" = "terraform"
+    "source"     = "github.com/humanitec-architecture/resource-pack-gcp"
+  }
+}

--- a/examples/dns/terraform.tfvars.example
+++ b/examples/dns/terraform.tfvars.example
@@ -1,7 +1,4 @@
 
-# GCP credentials
-credentials = ""
-
 # The name of the zone in which this record set will reside.
 managed_zone = ""
 

--- a/examples/dns/variables.tf
+++ b/examples/dns/variables.tf
@@ -8,11 +8,6 @@ variable "region" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "managed_zone" {
   description = "The name of the zone in which this record set will reside."
   type        = string

--- a/examples/gcp-pubsub/README.md
+++ b/examples/gcp-pubsub/README.md
@@ -80,12 +80,14 @@ graph LR;
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
+| google | ~> 5.17 |
 | humanitec | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| google | ~> 5.17 |
 | humanitec | ~> 1.0 |
 
 ## Modules
@@ -106,7 +108,11 @@ graph LR;
 
 | Name | Type |
 |------|------|
+| [google_project_iam_member.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_key.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.gcp_service_account_workload](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.gps_basic_subscriber](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.gpt_basic_publisher](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
@@ -121,7 +127,6 @@ graph LR;
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |
 | name | Name of the example application | `string` | `"hum-rp-gcp-pubsub-example"` | no |
 | prefix | n/a | `string` | `"hum-rp-gcp-pubsub-ex-"` | no |

--- a/examples/gcp-pubsub/main.tf
+++ b/examples/gcp-pubsub/main.tf
@@ -1,3 +1,35 @@
+# GCP service account used by Humanitec to provision resources
+
+resource "google_service_account" "humanitec_provisioner" {
+  account_id  = var.name
+  description = "Account used by Humanitec to provision resources"
+}
+
+resource "google_project_iam_member" "humanitec_provisioner" {
+  project = var.project
+  role    = "roles/owner"
+  member  = "serviceAccount:${google_service_account.humanitec_provisioner.email}"
+}
+
+resource "google_service_account_key" "humanitec_provisioner" {
+  service_account_id = google_service_account.humanitec_provisioner.name
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "gcp"
+
+  credentials = base64decode(google_service_account_key.humanitec_provisioner.private_key)
+
+  depends_on = [
+    # Otherwise the account looses permissions before the resources are deleted
+    google_project_iam_member.humanitec_provisioner
+  ]
+}
+
+# Example application and resource definition criteria
+
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -36,10 +68,11 @@ module "gcp_service_account_workload" {
 
   resource_packs_gcp_url = var.resource_packs_gcp_url
   resource_packs_gcp_rev = var.resource_packs_gcp_rev
+  append_logs_to_error   = true
+  driver_account         = humanitec_resource_account.humanitec_provisioner.id
 
-  project     = var.project
-  credentials = var.credentials
-  prefix      = var.prefix
+  project = var.project
+  prefix  = var.prefix
 
   name = "hrp-ps-$${context.res.id}"
 }

--- a/examples/gcp-pubsub/providers.tf
+++ b/examples/gcp-pubsub/providers.tf
@@ -1,5 +1,9 @@
 terraform {
   required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.17"
+    }
     humanitec = {
       source  = "humanitec/humanitec"
       version = "~> 1.0"
@@ -10,3 +14,12 @@ terraform {
 }
 
 provider "humanitec" {}
+
+provider "google" {
+  project = var.project
+
+  default_labels = {
+    "managed_by" = "terraform"
+    "source"     = "github.com/humanitec-architecture/resource-pack-gcp"
+  }
+}

--- a/examples/gcp-pubsub/pubsub_subscription.tf
+++ b/examples/gcp-pubsub/pubsub_subscription.tf
@@ -5,10 +5,11 @@ module "pubsub_subscription_basic" {
 
   resource_packs_gcp_url = var.resource_packs_gcp_url
   resource_packs_gcp_rev = var.resource_packs_gcp_rev
+  append_logs_to_error   = true
+  driver_account         = humanitec_resource_account.humanitec_provisioner.id
 
-  project     = var.project
-  credentials = var.credentials
-  prefix      = var.prefix
+  project = var.project
+  prefix  = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "pubsub_subscription_basic" {

--- a/examples/gcp-pubsub/pubsub_topic.tf
+++ b/examples/gcp-pubsub/pubsub_topic.tf
@@ -5,10 +5,11 @@ module "pubsub_topic_basic" {
 
   resource_packs_gcp_url = var.resource_packs_gcp_url
   resource_packs_gcp_rev = var.resource_packs_gcp_rev
+  append_logs_to_error   = true
+  driver_account         = humanitec_resource_account.humanitec_provisioner.id
 
-  project     = var.project
-  credentials = var.credentials
-  prefix      = var.prefix
+  project = var.project
+  prefix  = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "pubsub_topic_basic" {

--- a/examples/gcp-pubsub/terraform.tfvars.example
+++ b/examples/gcp-pubsub/terraform.tfvars.example
@@ -1,7 +1,4 @@
 
-# GCP credentials
-credentials = ""
-
 # Name of the example application
 name = "hum-rp-gcp-pubsub-example"
 

--- a/examples/gcp-pubsub/variables.tf
+++ b/examples/gcp-pubsub/variables.tf
@@ -3,11 +3,6 @@ variable "project" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "resource_packs_gcp_url" {
   description = "GCP Resource Pack git url"
   type        = string

--- a/examples/gcs/README.md
+++ b/examples/gcs/README.md
@@ -53,12 +53,14 @@ graph LR;
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
+| google | ~> 5.17 |
 | humanitec | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| google | ~> 5.17 |
 | humanitec | ~> 1.0 |
 
 ## Modules
@@ -78,7 +80,11 @@ graph LR;
 
 | Name | Type |
 |------|------|
+| [google_project_iam_member.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_key.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.gcp_service_account_workload](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.gcs_basic](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.gcs_basic_admin](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
@@ -92,7 +98,6 @@ graph LR;
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
 | location | The location of the bucket | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |
 | name | Name of the example application | `string` | `"hum-rp-gcs-example"` | no |

--- a/examples/gcs/main.tf
+++ b/examples/gcs/main.tf
@@ -1,3 +1,35 @@
+# GCP service account used by Humanitec to provision resources
+
+resource "google_service_account" "humanitec_provisioner" {
+  account_id  = var.name
+  description = "Account used by Humanitec to provision resources"
+}
+
+resource "google_project_iam_member" "humanitec_provisioner" {
+  project = var.project
+  role    = "roles/owner"
+  member  = "serviceAccount:${google_service_account.humanitec_provisioner.email}"
+}
+
+resource "google_service_account_key" "humanitec_provisioner" {
+  service_account_id = google_service_account.humanitec_provisioner.name
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "gcp"
+
+  credentials = base64decode(google_service_account_key.humanitec_provisioner.private_key)
+
+  depends_on = [
+    # Otherwise the account looses permissions before the resources are deleted
+    google_project_iam_member.humanitec_provisioner
+  ]
+}
+
+# Example application and resource definition criteria
+
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -22,9 +54,10 @@ module "gcs_basic" {
 
   resource_packs_gcp_url = var.resource_packs_gcp_url
   resource_packs_gcp_rev = var.resource_packs_gcp_rev
+  append_logs_to_error   = true
+  driver_account         = humanitec_resource_account.humanitec_provisioner.id
 
   project       = var.project
-  credentials   = var.credentials
   force_destroy = true
   location      = var.location
 
@@ -140,10 +173,11 @@ module "gcp_service_account_workload" {
 
   resource_packs_gcp_url = var.resource_packs_gcp_url
   resource_packs_gcp_rev = var.resource_packs_gcp_rev
+  append_logs_to_error   = true
+  driver_account         = humanitec_resource_account.humanitec_provisioner.id
 
-  project     = var.project
-  credentials = var.credentials
-  prefix      = var.prefix
+  project = var.project
+  prefix  = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "gcp_service_account_workload" {

--- a/examples/gcs/providers.tf
+++ b/examples/gcs/providers.tf
@@ -1,5 +1,9 @@
 terraform {
   required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.17"
+    }
     humanitec = {
       source  = "humanitec/humanitec"
       version = "~> 1.0"
@@ -10,3 +14,12 @@ terraform {
 }
 
 provider "humanitec" {}
+
+provider "google" {
+  project = var.project
+
+  default_labels = {
+    "managed_by" = "terraform"
+    "source"     = "github.com/humanitec-architecture/resource-pack-gcp"
+  }
+}

--- a/examples/gcs/terraform.tfvars.example
+++ b/examples/gcs/terraform.tfvars.example
@@ -1,7 +1,4 @@
 
-# GCP credentials
-credentials = ""
-
 # The location of the bucket
 location = ""
 

--- a/examples/gcs/variables.tf
+++ b/examples/gcs/variables.tf
@@ -3,11 +3,6 @@ variable "project" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "location" {
   description = "The location of the bucket"
   type        = string

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -69,9 +69,13 @@ graph LR;
 | Name | Type |
 |------|------|
 | [google_compute_global_address.private_ip_address](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_project_iam_member.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.servicenetworking](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_service_account.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_key.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
 | [google_service_networking_connection.private_vpc_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.mysql](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [google_compute_network.network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
 
@@ -79,7 +83,6 @@ graph LR;
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
 | private\_network | The VPC network from which the Cloud SQL instance is accessible for private IP. | `string` | n/a | yes |
 | project | n/a | `string` | n/a | yes |
 | region | GCP region | `string` | n/a | yes |

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -1,3 +1,35 @@
+# GCP service account used by Humanitec to provision resources
+
+resource "google_service_account" "humanitec_provisioner" {
+  account_id  = var.name
+  description = "Account used by Humanitec to provision resources"
+}
+
+resource "google_project_iam_member" "humanitec_provisioner" {
+  project = var.project
+  role    = "roles/owner"
+  member  = "serviceAccount:${google_service_account.humanitec_provisioner.email}"
+}
+
+resource "google_service_account_key" "humanitec_provisioner" {
+  service_account_id = google_service_account.humanitec_provisioner.name
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "gcp"
+
+  credentials = base64decode(google_service_account_key.humanitec_provisioner.private_key)
+
+  depends_on = [
+    # Otherwise the account looses permissions before the resources are deleted
+    google_project_iam_member.humanitec_provisioner
+  ]
+}
+
+# Example application and resource definition criteria
+
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -34,9 +66,10 @@ module "mysql" {
   prefix                 = var.prefix
   resource_packs_gcp_rev = var.resource_packs_gcp_rev
   resource_packs_gcp_url = var.resource_packs_gcp_url
+  append_logs_to_error   = true
+  driver_account         = humanitec_resource_account.humanitec_provisioner.id
   project                = var.project
   region                 = var.region
-  credentials            = var.credentials
 
   database_version = "MYSQL_8_0"
   tier             = "db-f1-micro"

--- a/examples/mysql/providers.tf
+++ b/examples/mysql/providers.tf
@@ -16,9 +16,8 @@ terraform {
 provider "humanitec" {}
 
 provider "google" {
-  project     = var.project
-  region      = var.region
-  credentials = var.credentials
+  project = var.project
+  region  = var.region
 
   default_labels = {
     "managed_by" = "terraform"

--- a/examples/mysql/terraform.tfvars.example
+++ b/examples/mysql/terraform.tfvars.example
@@ -1,7 +1,4 @@
 
-# GCP credentials
-credentials = ""
-
 # Name of the example application
 name = "hum-rp-mysql-example"
 

--- a/examples/mysql/variables.tf
+++ b/examples/mysql/variables.tf
@@ -29,11 +29,6 @@ variable "region" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "private_network" {
   type        = string
   description = "The VPC network from which the Cloud SQL instance is accessible for private IP."

--- a/examples/postgres/README.md
+++ b/examples/postgres/README.md
@@ -69,9 +69,13 @@ graph LR;
 | Name | Type |
 |------|------|
 | [google_compute_global_address.private_ip_address](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_project_iam_member.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.servicenetworking](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_service_account.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_key.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
 | [google_service_networking_connection.private_vpc_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.postgres](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [google_compute_network.network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
 
@@ -79,7 +83,6 @@ graph LR;
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
 | private\_network | The VPC network from which the Cloud SQL instance is accessible for private IP. | `string` | n/a | yes |
 | project | n/a | `string` | n/a | yes |
 | region | GCP region | `string` | n/a | yes |

--- a/examples/postgres/main.tf
+++ b/examples/postgres/main.tf
@@ -1,3 +1,35 @@
+# GCP service account used by Humanitec to provision resources
+
+resource "google_service_account" "humanitec_provisioner" {
+  account_id  = var.name
+  description = "Account used by Humanitec to provision resources"
+}
+
+resource "google_project_iam_member" "humanitec_provisioner" {
+  project = var.project
+  role    = "roles/owner"
+  member  = "serviceAccount:${google_service_account.humanitec_provisioner.email}"
+}
+
+resource "google_service_account_key" "humanitec_provisioner" {
+  service_account_id = google_service_account.humanitec_provisioner.name
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "gcp"
+
+  credentials = base64decode(google_service_account_key.humanitec_provisioner.private_key)
+
+  depends_on = [
+    # Otherwise the account looses permissions before the resources are deleted
+    google_project_iam_member.humanitec_provisioner
+  ]
+}
+
+# Example application and resource definition criteria
+
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -20,7 +52,7 @@ resource "google_compute_global_address" "private_ip_address" {
   network       = data.google_compute_network.network.id
 }
 
-# There is a bug 
+# There is a bug
 # walkaround `gcloud services vpc-peerings update --network=htc-ref-arch-vpc --ranges=hum-rp-mysql-ex-private-ip-address --service=servicenetworking.googleapis.com --force`
 resource "google_service_networking_connection" "private_vpc_connection" {
   network                 = data.google_compute_network.network.id
@@ -36,9 +68,10 @@ module "postgres" {
   prefix                 = var.prefix
   resource_packs_gcp_rev = var.resource_packs_gcp_rev
   resource_packs_gcp_url = var.resource_packs_gcp_url
+  append_logs_to_error   = true
+  driver_account         = humanitec_resource_account.humanitec_provisioner.id
   project                = var.project
   region                 = var.region
-  credentials            = var.credentials
 
   database_version = "POSTGRES_15"
   tier             = "db-f1-micro"

--- a/examples/postgres/providers.tf
+++ b/examples/postgres/providers.tf
@@ -16,9 +16,8 @@ terraform {
 provider "humanitec" {}
 
 provider "google" {
-  project     = var.project
-  region      = var.region
-  credentials = var.credentials
+  project = var.project
+  region  = var.region
 
   default_labels = {
     "managed_by" = "terraform"

--- a/examples/postgres/terraform.tfvars.example
+++ b/examples/postgres/terraform.tfvars.example
@@ -1,7 +1,4 @@
 
-# GCP credentials
-credentials = ""
-
 # Name of the example application
 name = "hum-rp-postgres-example"
 

--- a/examples/postgres/variables.tf
+++ b/examples/postgres/variables.tf
@@ -29,11 +29,6 @@ variable "region" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "private_network" {
   type        = string
   description = "The VPC network from which the Cloud SQL instance is accessible for private IP."

--- a/examples/redis/basic/README.md
+++ b/examples/redis/basic/README.md
@@ -49,12 +49,14 @@ graph LR;
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
+| google | ~> 5.17 |
 | humanitec | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| google | ~> 5.17 |
 | humanitec | ~> 1.0 |
 
 ## Modules
@@ -67,7 +69,11 @@ graph LR;
 
 | Name | Type |
 |------|------|
+| [google_project_iam_member.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_key.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.redis](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 
 ## Inputs
@@ -77,7 +83,6 @@ graph LR;
 | alternative\_location\_id | n/a | `string` | n/a | yes |
 | auth\_enabled | n/a | `bool` | n/a | yes |
 | authorized\_network | n/a | `string` | n/a | yes |
-| credentials | GCP credentials | `string` | n/a | yes |
 | humanitec\_org\_id | Humanitec organization where resource definitions will be applied | `string` | n/a | yes |
 | humanitec\_token | Humanitec API token | `string` | n/a | yes |
 | location\_id | n/a | `string` | n/a | yes |

--- a/examples/redis/basic/main.tf
+++ b/examples/redis/basic/main.tf
@@ -1,3 +1,35 @@
+# GCP service account used by Humanitec to provision resources
+
+resource "google_service_account" "humanitec_provisioner" {
+  account_id  = var.name
+  description = "Account used by Humanitec to provision resources"
+}
+
+resource "google_project_iam_member" "humanitec_provisioner" {
+  project = var.project
+  role    = "roles/owner"
+  member  = "serviceAccount:${google_service_account.humanitec_provisioner.email}"
+}
+
+resource "google_service_account_key" "humanitec_provisioner" {
+  service_account_id = google_service_account.humanitec_provisioner.name
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "gcp"
+
+  credentials = base64decode(google_service_account_key.humanitec_provisioner.private_key)
+
+  depends_on = [
+    # Otherwise the account looses permissions before the resources are deleted
+    google_project_iam_member.humanitec_provisioner
+  ]
+}
+
+# Example application and resource definition criteria
+
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -9,9 +41,10 @@ module "redis" {
   prefix                  = var.prefix
   resource_packs_gcp_rev  = var.resource_packs_gcp_rev
   resource_packs_gcp_url  = var.resource_packs_gcp_url
+  append_logs_to_error    = true
+  driver_account          = humanitec_resource_account.humanitec_provisioner.id
   project                 = var.project
   region                  = var.region
-  credentials             = var.credentials
   memory_size_gb          = var.memory_size_gb
   location_id             = var.location_id
   alternative_location_id = var.alternative_location_id
@@ -22,4 +55,5 @@ module "redis" {
 resource "humanitec_resource_definition_criteria" "redis" {
   resource_definition_id = module.redis.id
   app_id                 = humanitec_application.example.id
+  force_delete           = true
 }

--- a/examples/redis/basic/providers.tf
+++ b/examples/redis/basic/providers.tf
@@ -1,5 +1,9 @@
 terraform {
   required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.17"
+    }
     humanitec = {
       source  = "humanitec/humanitec"
       version = "~> 1.0"
@@ -13,4 +17,14 @@ provider "humanitec" {
   host   = var.humanitec_host
   org_id = var.humanitec_org_id
   token  = var.humanitec_token
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+
+  default_labels = {
+    "managed_by" = "terraform"
+    "source"     = "github.com/humanitec-architecture/resource-pack-gcp"
+  }
 }

--- a/examples/redis/basic/terraform.tfvars.example
+++ b/examples/redis/basic/terraform.tfvars.example
@@ -2,9 +2,6 @@ alternative_location_id = ""
 auth_enabled            = ""
 authorized_network      = ""
 
-# GCP credentials
-credentials = ""
-
 # Humanitec API host url
 humanitec_host = "https://api.humanitec.io"
 

--- a/examples/redis/basic/variables.tf
+++ b/examples/redis/basic/variables.tf
@@ -45,11 +45,6 @@ variable "region" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "memory_size_gb" {
   type = number
 }

--- a/humanitec-resource-defs/dns/basic/README.md
+++ b/humanitec-resource-defs/dns/basic/README.md
@@ -22,12 +22,13 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | managed\_zone | The name of the zone in which this record set will reside. | `string` | n/a | yes |
 | managed\_zone\_dns\_name | The DNS name of the managed zone. | `string` | n/a | yes |
 | prefix | n/a | `string` | n/a | yes |
 | project | n/a | `string` | n/a | yes |
 | region | GCP region | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | resource\_packs\_gcp\_rev | n/a | `string` | `"ref/heads/main"` | no |
 | resource\_packs\_gcp\_url | n/a | `string` | `"https://github.com/humanitec-architecture/resource-packs-gcp.git"` | no |
 

--- a/humanitec-resource-defs/dns/basic/main.tf
+++ b/humanitec-resource-defs/dns/basic/main.tf
@@ -4,18 +4,21 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}clouddns-basic"
   type        = "dns"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        credentials = var.credentials
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/dns/basic"
         rev  = var.resource_packs_gcp_rev
         url  = var.resource_packs_gcp_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          GOOGLE_CREDENTIALS = "*"
+        }
       }
 
       variables = {

--- a/humanitec-resource-defs/dns/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/dns/basic/terraform.tfvars.example
@@ -1,6 +1,9 @@
 
-# GCP credentials
-credentials = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # The name of the zone in which this record set will reside.
 managed_zone = ""

--- a/humanitec-resource-defs/dns/basic/variables.tf
+++ b/humanitec-resource-defs/dns/basic/variables.tf
@@ -12,17 +12,23 @@ variable "resource_packs_gcp_url" {
   default = "https://github.com/humanitec-architecture/resource-packs-gcp.git"
 }
 
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
+}
+
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
+  type        = string
+}
+
 variable "project" {
   type = string
 }
 
 variable "region" {
   description = "GCP region"
-  type        = string
-}
-
-variable "credentials" {
-  description = "GCP credentials"
   type        = string
 }
 

--- a/humanitec-resource-defs/gcp-pubsub-subscription/basic/README.md
+++ b/humanitec-resource-defs/gcp-pubsub-subscription/basic/README.md
@@ -22,9 +22,10 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | prefix | Name prefix | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | resource\_packs\_gcp\_rev | GCP Resource Pack git ref | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_gcp\_url | GCP Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-gcp.git"` | no |

--- a/humanitec-resource-defs/gcp-pubsub-subscription/basic/main.tf
+++ b/humanitec-resource-defs/gcp-pubsub-subscription/basic/main.tf
@@ -4,18 +4,21 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}gcp-pubsub-subscription-basic"
   type        = "gcp-pubsub-subscription"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        credentials = var.credentials
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/gcp-pubsub-subscription/basic"
         rev  = var.resource_packs_gcp_rev
         url  = var.resource_packs_gcp_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          GOOGLE_CREDENTIALS = "*"
+        }
       }
 
       variables = {

--- a/humanitec-resource-defs/gcp-pubsub-subscription/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/gcp-pubsub-subscription/basic/terraform.tfvars.example
@@ -1,6 +1,9 @@
 
-# GCP credentials
-credentials = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Resource name (can contain placeholders like ${context.app.id})
 name = ""

--- a/humanitec-resource-defs/gcp-pubsub-subscription/basic/variables.tf
+++ b/humanitec-resource-defs/gcp-pubsub-subscription/basic/variables.tf
@@ -10,13 +10,19 @@ variable "resource_packs_gcp_rev" {
   default     = "refs/heads/main"
 }
 
-variable "project" {
-  description = "GCP project ID"
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
+}
+
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
+variable "project" {
+  description = "GCP project ID"
   type        = string
 }
 

--- a/humanitec-resource-defs/gcp-pubsub-topic/basic/README.md
+++ b/humanitec-resource-defs/gcp-pubsub-topic/basic/README.md
@@ -22,9 +22,10 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | prefix | Name prefix | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | resource\_packs\_gcp\_rev | GCP Resource Pack git ref | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_gcp\_url | GCP Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-gcp.git"` | no |

--- a/humanitec-resource-defs/gcp-pubsub-topic/basic/main.tf
+++ b/humanitec-resource-defs/gcp-pubsub-topic/basic/main.tf
@@ -4,18 +4,21 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}gcp-pubsub-topic-basic"
   type        = "gcp-pubsub-topic"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        credentials = var.credentials
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/gcp-pubsub-topic/basic"
         rev  = var.resource_packs_gcp_rev
         url  = var.resource_packs_gcp_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          GOOGLE_CREDENTIALS = "*"
+        }
       }
 
       variables = {

--- a/humanitec-resource-defs/gcp-pubsub-topic/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/gcp-pubsub-topic/basic/terraform.tfvars.example
@@ -1,6 +1,9 @@
 
-# GCP credentials
-credentials = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Resource name (can contain placeholders like ${context.app.id})
 name = ""

--- a/humanitec-resource-defs/gcp-pubsub-topic/basic/variables.tf
+++ b/humanitec-resource-defs/gcp-pubsub-topic/basic/variables.tf
@@ -10,13 +10,19 @@ variable "resource_packs_gcp_rev" {
   default     = "refs/heads/main"
 }
 
-variable "project" {
-  description = "GCP project ID"
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
+}
+
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
+variable "project" {
+  description = "GCP project ID"
   type        = string
 }
 

--- a/humanitec-resource-defs/gcp-service-account/workload/README.md
+++ b/humanitec-resource-defs/gcp-service-account/workload/README.md
@@ -22,9 +22,10 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | prefix | n/a | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | resource\_packs\_gcp\_rev | GCP Resource Pack git ref | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_gcp\_url | GCP Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-gcp.git"` | no |

--- a/humanitec-resource-defs/gcp-service-account/workload/main.tf
+++ b/humanitec-resource-defs/gcp-service-account/workload/main.tf
@@ -4,18 +4,21 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}gcp-service-account-workload"
   type        = "gcp-service-account"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        credentials = var.credentials
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/gcp-service-account/workload"
         rev  = var.resource_packs_gcp_rev
         url  = var.resource_packs_gcp_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          GOOGLE_CREDENTIALS = "*"
+        }
       }
 
       variables = {

--- a/humanitec-resource-defs/gcp-service-account/workload/terraform.tfvars.example
+++ b/humanitec-resource-defs/gcp-service-account/workload/terraform.tfvars.example
@@ -1,6 +1,9 @@
 
-# GCP credentials
-credentials = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Resource name (can contain placeholders like ${context.app.id})
 name = ""

--- a/humanitec-resource-defs/gcp-service-account/workload/variables.tf
+++ b/humanitec-resource-defs/gcp-service-account/workload/variables.tf
@@ -13,11 +13,6 @@ variable "project" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "roles" {
   description = "List of roles to assign to the service account"
   type        = set(string)
@@ -34,4 +29,15 @@ variable "resource_packs_gcp_rev" {
   description = "GCP Resource Pack git ref"
   type        = string
   default     = "refs/heads/main"
+}
+
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
+}
+
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
+  type        = string
 }

--- a/humanitec-resource-defs/gcs/basic/README.md
+++ b/humanitec-resource-defs/gcs/basic/README.md
@@ -22,10 +22,11 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | location | The location of the bucket | `string` | n/a | yes |
 | prefix | Prefix for all resources | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | force\_destroy | Whether to force destroy the bucket when deleting | `bool` | `false` | no |
 | name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | resource\_packs\_gcp\_rev | GCP Resource Pack git ref | `string` | `"refs/heads/main"` | no |

--- a/humanitec-resource-defs/gcs/basic/main.tf
+++ b/humanitec-resource-defs/gcs/basic/main.tf
@@ -4,18 +4,21 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}gcs-basic"
   type        = "gcs"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        credentials = var.credentials
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/gcs/basic"
         rev  = var.resource_packs_gcp_rev
         url  = var.resource_packs_gcp_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          GOOGLE_CREDENTIALS = "*"
+        }
       }
 
       variables = {

--- a/humanitec-resource-defs/gcs/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/gcs/basic/terraform.tfvars.example
@@ -1,6 +1,9 @@
 
-# GCP credentials
-credentials = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Whether to force destroy the bucket when deleting
 force_destroy = false

--- a/humanitec-resource-defs/gcs/basic/variables.tf
+++ b/humanitec-resource-defs/gcs/basic/variables.tf
@@ -10,13 +10,19 @@ variable "resource_packs_gcp_rev" {
   default     = "refs/heads/main"
 }
 
-variable "project" {
-  description = "GCP project ID"
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
+}
+
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
+variable "project" {
+  description = "GCP project ID"
   type        = string
 }
 

--- a/humanitec-resource-defs/k8s/service-account/main.tf
+++ b/humanitec-resource-defs/k8s/service-account/main.tf
@@ -5,15 +5,8 @@ resource "humanitec_resource_definition" "main" {
 
   driver_type = "humanitec/template"
   driver_inputs = {
-    secrets_string = jsonencode({
-      templates = {
-        # outputs = ""
-      }
-    })
-
     values_string = jsonencode({
       templates = {
-        # cookie    = ""
         init      = ""
         manifests = <<EOL
 serviceaccount.yaml:

--- a/humanitec-resource-defs/mysql/basic/README.md
+++ b/humanitec-resource-defs/mysql/basic/README.md
@@ -22,13 +22,14 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
 | database\_version | The MySQL, PostgreSQL or SQL Server version to use. | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | prefix | Prefix for all resources | `string` | n/a | yes |
 | private\_network | The VPC network from which the Cloud SQL instance is accessible for private IP. | `string` | n/a | yes |
 | project | n/a | `string` | n/a | yes |
 | region | GCP region | `string` | n/a | yes |
 | tier | The machine type to use. | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | resource\_packs\_gcp\_rev | n/a | `string` | `"ref/heads/main"` | no |
 | resource\_packs\_gcp\_url | n/a | `string` | `"https://github.com/humanitec-architecture/resource-packs-gcp.git"` | no |

--- a/humanitec-resource-defs/mysql/basic/main.tf
+++ b/humanitec-resource-defs/mysql/basic/main.tf
@@ -4,19 +4,21 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}cloudsql-mysql"
   type        = "mysql"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        credentials = var.credentials
-      }
-
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/cloudsql/basic"
         rev  = var.resource_packs_gcp_rev
         url  = var.resource_packs_gcp_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          GOOGLE_CREDENTIALS = "*"
+        }
       }
 
       variables = {

--- a/humanitec-resource-defs/mysql/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/mysql/basic/terraform.tfvars.example
@@ -1,9 +1,12 @@
 
-# GCP credentials
-credentials = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
 
 # The MySQL, PostgreSQL or SQL Server version to use.
 database_version = ""
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Resource name (can contain placeholders like ${context.app.id})
 name = ""

--- a/humanitec-resource-defs/mysql/basic/variables.tf
+++ b/humanitec-resource-defs/mysql/basic/variables.tf
@@ -13,17 +13,23 @@ variable "resource_packs_gcp_url" {
   default = "https://github.com/humanitec-architecture/resource-packs-gcp.git"
 }
 
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
+}
+
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
+  type        = string
+}
+
 variable "project" {
   type = string
 }
 
 variable "region" {
   description = "GCP region"
-  type        = string
-}
-
-variable "credentials" {
-  description = "GCP credentials"
   type        = string
 }
 

--- a/humanitec-resource-defs/postgres/basic/README.md
+++ b/humanitec-resource-defs/postgres/basic/README.md
@@ -22,13 +22,14 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| credentials | GCP credentials | `string` | n/a | yes |
 | database\_version | The MySQL, PostgreSQL or SQL Server version to use. | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | prefix | Prefix for all resources | `string` | n/a | yes |
 | private\_network | The VPC network from which the Cloud SQL instance is accessible for private IP. | `string` | n/a | yes |
 | project | n/a | `string` | n/a | yes |
 | region | GCP region | `string` | n/a | yes |
 | tier | The machine type to use. | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | resource\_packs\_gcp\_rev | n/a | `string` | `"ref/heads/main"` | no |
 | resource\_packs\_gcp\_url | n/a | `string` | `"https://github.com/humanitec-architecture/resource-packs-gcp.git"` | no |

--- a/humanitec-resource-defs/postgres/basic/main.tf
+++ b/humanitec-resource-defs/postgres/basic/main.tf
@@ -4,19 +4,21 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}cloudsql-postgres"
   type        = "postgres"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        credentials = var.credentials
-      }
-
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/cloudsql/basic"
         rev  = var.resource_packs_gcp_rev
         url  = var.resource_packs_gcp_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          GOOGLE_CREDENTIALS = "*"
+        }
       }
 
       variables = {

--- a/humanitec-resource-defs/postgres/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/postgres/basic/terraform.tfvars.example
@@ -1,9 +1,12 @@
 
-# GCP credentials
-credentials = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
 
 # The MySQL, PostgreSQL or SQL Server version to use.
 database_version = ""
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Resource name (can contain placeholders like ${context.app.id})
 name = ""

--- a/humanitec-resource-defs/postgres/basic/variables.tf
+++ b/humanitec-resource-defs/postgres/basic/variables.tf
@@ -13,17 +13,23 @@ variable "resource_packs_gcp_url" {
   default = "https://github.com/humanitec-architecture/resource-packs-gcp.git"
 }
 
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
+}
+
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
+  type        = string
+}
+
 variable "project" {
   type = string
 }
 
 variable "region" {
   description = "GCP region"
-  type        = string
-}
-
-variable "credentials" {
-  description = "GCP credentials"
   type        = string
 }
 

--- a/humanitec-resource-defs/redis/basic/README.md
+++ b/humanitec-resource-defs/redis/basic/README.md
@@ -24,12 +24,13 @@
 |------|-------------|------|---------|:--------:|
 | alternative\_location\_id | n/a | `string` | n/a | yes |
 | authorized\_network | n/a | `string` | n/a | yes |
-| credentials | GCP credentials | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | location\_id | n/a | `string` | n/a | yes |
 | memory\_size\_gb | n/a | `number` | n/a | yes |
 | prefix | Prefix for all resources | `string` | n/a | yes |
 | project | n/a | `string` | n/a | yes |
 | region | GCP region | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | auth\_enabled | n/a | `bool` | `false` | no |
 | display\_name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |

--- a/humanitec-resource-defs/redis/basic/main.tf
+++ b/humanitec-resource-defs/redis/basic/main.tf
@@ -4,19 +4,21 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}memorystore-redis"
   type        = "redis"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        credentials = var.credentials
-      }
-
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/redis/basic"
         rev  = var.resource_packs_gcp_rev
         url  = var.resource_packs_gcp_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          GOOGLE_CREDENTIALS = "*"
+        }
       }
 
       variables = {

--- a/humanitec-resource-defs/redis/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/redis/basic/terraform.tfvars.example
@@ -1,12 +1,16 @@
 alternative_location_id = ""
-auth_enabled            = false
-authorized_network      = ""
 
-# GCP credentials
-credentials = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
+
+auth_enabled       = false
+authorized_network = ""
 
 # Resource name (can contain placeholders like ${context.app.id})
 display_name = ""
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 location_id    = ""
 memory_size_gb = ""

--- a/humanitec-resource-defs/redis/basic/variables.tf
+++ b/humanitec-resource-defs/redis/basic/variables.tf
@@ -13,17 +13,23 @@ variable "resource_packs_gcp_url" {
   default = "https://github.com/humanitec-architecture/resource-packs-gcp.git"
 }
 
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
+}
+
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
+  type        = string
+}
+
 variable "project" {
   type = string
 }
 
 variable "region" {
   description = "GCP region"
-  type        = string
-}
-
-variable "credentials" {
-  description = "GCP credentials"
   type        = string
 }
 

--- a/humanitec-resource-defs/workload/service-account/main.tf
+++ b/humanitec-resource-defs/workload/service-account/main.tf
@@ -7,7 +7,6 @@ resource "humanitec_resource_definition" "main" {
   driver_inputs = {
     values_string = jsonencode({
       templates = {
-        # cookie    = ""
         init    = ""
         outputs = <<EOL
 update:

--- a/modules/cloudsql/basic/README.md
+++ b/modules/cloudsql/basic/README.md
@@ -28,7 +28,6 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
-| credentials | GCP credentials | `string` | n/a | yes |
 | database\_version | The MySQL, PostgreSQL or SQL Server version to use. | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | port | The port for the database (needs to match the database type) | `number` | n/a | yes |

--- a/modules/cloudsql/basic/providers.tf
+++ b/modules/cloudsql/basic/providers.tf
@@ -14,9 +14,8 @@ terraform {
 }
 
 provider "google" {
-  project     = var.project
-  region      = var.region
-  credentials = var.credentials
+  project = var.project
+  region  = var.region
 
   default_labels = {
     "humanitec"  = "true"

--- a/modules/cloudsql/basic/terraform.tfvars.example
+++ b/modules/cloudsql/basic/terraform.tfvars.example
@@ -1,8 +1,5 @@
 app_id = ""
 
-# GCP credentials
-credentials = ""
-
 # The MySQL, PostgreSQL or SQL Server version to use.
 database_version = ""
 

--- a/modules/cloudsql/basic/variables.tf
+++ b/modules/cloudsql/basic/variables.tf
@@ -13,11 +13,6 @@ variable "region" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "app_id" {
   type = string
 }

--- a/modules/dns/basic/README.md
+++ b/modules/dns/basic/README.md
@@ -23,7 +23,6 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
-| credentials | GCP credentials | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | managed\_zone | The name of the zone in which this record set will reside. | `string` | n/a | yes |
 | managed\_zone\_dns\_name | The DNS name of the managed zone. | `string` | n/a | yes |

--- a/modules/dns/basic/providers.tf
+++ b/modules/dns/basic/providers.tf
@@ -10,9 +10,8 @@ terraform {
 }
 
 provider "google" {
-  project     = var.project
-  region      = var.region
-  credentials = var.credentials
+  project = var.project
+  region  = var.region
 
   default_labels = {
     "humanitec"  = "true"

--- a/modules/dns/basic/terraform.tfvars.example
+++ b/modules/dns/basic/terraform.tfvars.example
@@ -1,8 +1,4 @@
 app_id = ""
-
-# GCP credentials
-credentials = ""
-
 env_id = ""
 
 # The IPv4 address that the DNS name should resolve to.

--- a/modules/dns/basic/variables.tf
+++ b/modules/dns/basic/variables.tf
@@ -8,11 +8,6 @@ variable "region" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "app_id" {
   type = string
 }

--- a/modules/gcp-pubsub-subscription/basic/README.md
+++ b/modules/gcp-pubsub-subscription/basic/README.md
@@ -23,7 +23,6 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
-| credentials | GCP credentials | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | prefix | n/a | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |

--- a/modules/gcp-pubsub-subscription/basic/providers.tf
+++ b/modules/gcp-pubsub-subscription/basic/providers.tf
@@ -10,8 +10,7 @@ terraform {
 }
 
 provider "google" {
-  project     = var.project
-  credentials = var.credentials
+  project = var.project
 
   default_labels = {
     "humanitec"  = "true"

--- a/modules/gcp-pubsub-subscription/basic/terraform.tfvars.example
+++ b/modules/gcp-pubsub-subscription/basic/terraform.tfvars.example
@@ -1,8 +1,4 @@
 app_id = ""
-
-# GCP credentials
-credentials = ""
-
 env_id = ""
 name   = ""
 prefix = ""

--- a/modules/gcp-pubsub-subscription/basic/variables.tf
+++ b/modules/gcp-pubsub-subscription/basic/variables.tf
@@ -24,11 +24,6 @@ variable "project" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "topic_name" {
   description = "Name of the topic resource"
   type        = string

--- a/modules/gcp-pubsub-topic/basic/README.md
+++ b/modules/gcp-pubsub-topic/basic/README.md
@@ -23,7 +23,6 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
-| credentials | GCP credentials | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | prefix | n/a | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |

--- a/modules/gcp-pubsub-topic/basic/providers.tf
+++ b/modules/gcp-pubsub-topic/basic/providers.tf
@@ -10,8 +10,7 @@ terraform {
 }
 
 provider "google" {
-  project     = var.project
-  credentials = var.credentials
+  project = var.project
 
   default_labels = {
     "humanitec"  = "true"

--- a/modules/gcp-pubsub-topic/basic/terraform.tfvars.example
+++ b/modules/gcp-pubsub-topic/basic/terraform.tfvars.example
@@ -1,8 +1,4 @@
 app_id = ""
-
-# GCP credentials
-credentials = ""
-
 env_id = ""
 name   = ""
 prefix = ""

--- a/modules/gcp-pubsub-topic/basic/variables.tf
+++ b/modules/gcp-pubsub-topic/basic/variables.tf
@@ -23,8 +23,3 @@ variable "project" {
   description = "GCP project ID"
   type        = string
 }
-
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}

--- a/modules/gcp-service-account/workload/README.md
+++ b/modules/gcp-service-account/workload/README.md
@@ -29,7 +29,6 @@
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
 | bindings | List of additional bindings to grant to the service account | `set(string)` | n/a | yes |
-| credentials | GCP credentials | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | namespace | k8s namespace | `string` | n/a | yes |
 | prefix | Prefix for all resources | `string` | n/a | yes |

--- a/modules/gcp-service-account/workload/providers.tf
+++ b/modules/gcp-service-account/workload/providers.tf
@@ -10,8 +10,7 @@ terraform {
 }
 
 provider "google" {
-  project     = var.project
-  credentials = var.credentials
+  project = var.project
 
   default_labels = {
     "humanitec"  = "true"

--- a/modules/gcp-service-account/workload/terraform.tfvars.example
+++ b/modules/gcp-service-account/workload/terraform.tfvars.example
@@ -3,9 +3,6 @@ app_id = ""
 # List of additional bindings to grant to the service account
 bindings = ""
 
-# GCP credentials
-credentials = ""
-
 env_id = ""
 
 # Resource name

--- a/modules/gcp-service-account/workload/variables.tf
+++ b/modules/gcp-service-account/workload/variables.tf
@@ -26,11 +26,6 @@ variable "project" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "namespace" {
   description = "k8s namespace"
   type        = string

--- a/modules/gcs/basic/README.md
+++ b/modules/gcs/basic/README.md
@@ -23,7 +23,6 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
-| credentials | GCP credentials | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | location | The location of the bucket | `string` | n/a | yes |
 | prefix | Prefix for all resources | `string` | n/a | yes |

--- a/modules/gcs/basic/providers.tf
+++ b/modules/gcs/basic/providers.tf
@@ -10,8 +10,7 @@ terraform {
 }
 
 provider "google" {
-  project     = var.project
-  credentials = var.credentials
+  project = var.project
 
   default_labels = {
     "humanitec"  = "true"

--- a/modules/gcs/basic/terraform.tfvars.example
+++ b/modules/gcs/basic/terraform.tfvars.example
@@ -1,8 +1,4 @@
 app_id = ""
-
-# GCP credentials
-credentials = ""
-
 env_id = ""
 
 # Whether to force destroy the bucket when deleting

--- a/modules/gcs/basic/variables.tf
+++ b/modules/gcs/basic/variables.tf
@@ -26,11 +26,6 @@ variable "project" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "force_destroy" {
   description = "Whether to force destroy the bucket when deleting"
   type        = bool

--- a/modules/redis/basic/README.md
+++ b/modules/redis/basic/README.md
@@ -25,7 +25,6 @@
 | alternative\_location\_id | n/a | `string` | n/a | yes |
 | app\_id | n/a | `string` | n/a | yes |
 | authorized\_network | n/a | `string` | n/a | yes |
-| credentials | GCP credentials | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | location\_id | n/a | `string` | n/a | yes |
 | memory\_size\_gb | n/a | `number` | n/a | yes |

--- a/modules/redis/basic/providers.tf
+++ b/modules/redis/basic/providers.tf
@@ -10,9 +10,8 @@ terraform {
 }
 
 provider "google" {
-  project     = var.project
-  region      = var.region
-  credentials = jsonencode(var.credentials)
+  project = var.project
+  region  = var.region
 
   default_labels = {
     "humanitec"  = "true"

--- a/modules/redis/basic/terraform.tfvars.example
+++ b/modules/redis/basic/terraform.tfvars.example
@@ -3,9 +3,6 @@ app_id                  = ""
 auth_enabled            = false
 authorized_network      = ""
 
-# GCP credentials
-credentials = ""
-
 # Resource display name
 display_name = ""
 

--- a/modules/redis/basic/variables.tf
+++ b/modules/redis/basic/variables.tf
@@ -13,11 +13,6 @@ variable "region" {
   type        = string
 }
 
-variable "credentials" {
-  description = "GCP credentials"
-  type        = string
-}
-
 variable "app_id" {
   type = string
 }


### PR DESCRIPTION
Use a [resource account](https://developer.humanitec.com/platform-orchestrator/security/cloud-accounts/gcp/) to inject credentials instead of directly injecting them into the driver.

This will allow us to use temporary credentials in the future.

So far the account role is fairly wide, but we can narrow it down in the future. As most resources need to provision GCP service accounts, the provisioner role needs to be always fairly powerful though. 