### PR TITLE
feat: re-use google_dns_managed_zone data source

### DIFF
--- a/examples/dns/README.md
+++ b/examples/dns/README.md
@@ -86,7 +86,6 @@ graph LR;
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | managed\_zone | The name of the zone in which this record set will reside. | `string` | n/a | yes |
-| managed\_zone\_dns\_name | The DNS name of the managed zone. | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |
 | region | GCP region | `string` | n/a | yes |
 | name | Name of the example application | `string` | `"hum-rp-dns-example"` | no |

--- a/examples/dns/main.tf
+++ b/examples/dns/main.tf
@@ -50,8 +50,7 @@ module "dns_basic" {
   project = var.project
   region  = var.region
 
-  managed_zone          = var.managed_zone
-  managed_zone_dns_name = var.managed_zone_dns_name
+  managed_zone = var.managed_zone
 }
 
 resource "humanitec_resource_definition_criteria" "dns_basic" {

--- a/examples/dns/terraform.tfvars.example
+++ b/examples/dns/terraform.tfvars.example
@@ -2,9 +2,6 @@
 # The name of the zone in which this record set will reside.
 managed_zone = ""
 
-# The DNS name of the managed zone.
-managed_zone_dns_name = ""
-
 # Name of the example application
 name = "hum-rp-dns-example"
 

--- a/examples/dns/variables.tf
+++ b/examples/dns/variables.tf
@@ -13,11 +13,6 @@ variable "managed_zone" {
   type        = string
 }
 
-variable "managed_zone_dns_name" {
-  description = "The DNS name of the managed zone."
-  type        = string
-}
-
 variable "name" {
   description = "Name of the example application"
   type        = string

--- a/humanitec-resource-defs/dns/basic/README.md
+++ b/humanitec-resource-defs/dns/basic/README.md
@@ -24,7 +24,6 @@
 |------|-------------|------|---------|:--------:|
 | driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | managed\_zone | The name of the zone in which this record set will reside. | `string` | n/a | yes |
-| managed\_zone\_dns\_name | The DNS name of the managed zone. | `string` | n/a | yes |
 | prefix | n/a | `string` | n/a | yes |
 | project | n/a | `string` | n/a | yes |
 | region | GCP region | `string` | n/a | yes |

--- a/humanitec-resource-defs/dns/basic/main.tf
+++ b/humanitec-resource-defs/dns/basic/main.tf
@@ -22,14 +22,13 @@ resource "humanitec_resource_definition" "main" {
       }
 
       variables = {
-        project               = var.project
-        region                = var.region
-        app_id                = "$${context.app.id}"
-        env_id                = "$${context.env.id}"
-        res_id                = "$${context.res.id}"
-        managed_zone          = var.managed_zone
-        managed_zone_dns_name = var.managed_zone_dns_name
-        subdomain             = "$${context.app.id}-$${context.env.id}"
+        project      = var.project
+        region       = var.region
+        app_id       = "$${context.app.id}"
+        env_id       = "$${context.env.id}"
+        res_id       = "$${context.res.id}"
+        managed_zone = var.managed_zone
+        subdomain    = "$${context.app.id}-$${context.env.id}"
       }
     })
   }

--- a/humanitec-resource-defs/dns/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/dns/basic/terraform.tfvars.example
@@ -8,9 +8,6 @@ driver_account = ""
 # The name of the zone in which this record set will reside.
 managed_zone = ""
 
-# The DNS name of the managed zone.
-managed_zone_dns_name = ""
-
 prefix  = ""
 project = ""
 

--- a/humanitec-resource-defs/dns/basic/variables.tf
+++ b/humanitec-resource-defs/dns/basic/variables.tf
@@ -36,8 +36,3 @@ variable "managed_zone" {
   description = "The name of the zone in which this record set will reside."
   type        = string
 }
-
-variable "managed_zone_dns_name" {
-  description = "The DNS name of the managed zone."
-  type        = string
-}

--- a/modules/dns/basic/README.md
+++ b/modules/dns/basic/README.md
@@ -4,19 +4,20 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
-| google | ~> 5.17 |
+| google | ~> 5.26 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 5.17 |
+| google | ~> 5.26 |
 
 ### Resources
 
 | Name | Type |
 |------|------|
 | [google_dns_record_set.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_dns_managed_zone.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone) | data source |
 
 ### Inputs
 
@@ -25,7 +26,6 @@
 | app\_id | n/a | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | managed\_zone | The name of the zone in which this record set will reside. | `string` | n/a | yes |
-| managed\_zone\_dns\_name | The DNS name of the managed zone. | `string` | n/a | yes |
 | project | GCP project ID | `string` | n/a | yes |
 | region | GCP region | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |

--- a/modules/dns/basic/main.tf
+++ b/modules/dns/basic/main.tf
@@ -1,7 +1,6 @@
-# Disabled due to https://github.com/hashicorp/terraform-provider-google/issues/16832
-# data "google_dns_managed_zone" "main" {
-#   name = var.managed_zone
-# }
+data "google_dns_managed_zone" "main" {
+  name = var.managed_zone
+}
 
 locals {
   types   = ["A", "AAAA", "CNAME"]
@@ -13,11 +12,8 @@ locals {
 }
 
 resource "google_dns_record_set" "main" {
-  # name         = "${var.subdomain}.${data.google_dns_managed_zone.main.dns_name}"
-  # managed_zone = data.google_dns_managed_zone.main.name
-
-  name         = "${var.subdomain}.${var.managed_zone_dns_name}"
-  managed_zone = var.managed_zone
+  name         = "${var.subdomain}.${data.google_dns_managed_zone.main.dns_name}"
+  managed_zone = data.google_dns_managed_zone.main.name
   type         = local.type
   ttl          = 300
 

--- a/modules/dns/basic/providers.tf
+++ b/modules/dns/basic/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.17"
+      version = "~> 5.26"
     }
   }
 

--- a/modules/dns/basic/terraform.tfvars.example
+++ b/modules/dns/basic/terraform.tfvars.example
@@ -10,9 +10,6 @@ ipv6_address = ""
 # The name of the zone in which this record set will reside.
 managed_zone = ""
 
-# The DNS name of the managed zone.
-managed_zone_dns_name = ""
-
 # A valid fully qualified domain name that the DNS name should resolve to.
 name = ""
 

--- a/modules/dns/basic/variables.tf
+++ b/modules/dns/basic/variables.tf
@@ -25,11 +25,6 @@ variable "managed_zone" {
   type        = string
 }
 
-variable "managed_zone_dns_name" {
-  description = "The DNS name of the managed zone."
-  type        = string
-}
-
 variable "ip_address" {
   description = "The IPv4 address that the DNS name should resolve to."
   type        = string


### PR DESCRIPTION
Simplify the dns resource pack by re-enabling the `google_dns_managed_zone` data source.

Requires:
- [x] Release of https://github.com/hashicorp/terraform-provider-google/commit/0295085102b600e48486256d0e90376209789afe