### PR TITLE
Fix Mermaid chart layout

### DIFF
--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -33,7 +33,7 @@ This example uses username and password authentication, checkout [../postgres/RE
 ```mermaid
 graph TD;
   subgraph VPC
-    subgraph server["MySQL CloudSQL Database Instance"]
+    subgraph server["MySQL&nbsp;CloudSQL&nbsp;Database&nbsp;Instance"]
       database["CloudSQL Database"]
       user["CloudSQL User"]
     end

--- a/examples/postgres/README.md
+++ b/examples/postgres/README.md
@@ -40,7 +40,7 @@ subgraph GCP IAM
 end
 
 subgraph VPC
-    subgraph server["PostgreSQL CloudSQL Database Instance"]
+    subgraph server["PostgreSQL&nbsp;CloudSQL&nbsp;Database&nbsp;Instance"]
         database["CloudSQL Database"]
         user["CloudSQL User"]
     end


### PR DESCRIPTION
This PR fixes a layout issue in Mermaid charts by preventing word wrap in a subgraph.

Before:
![image](https://github.com/user-attachments/assets/1d63343c-4f91-44bd-90ab-a3503831f45b)

After:
![image](https://github.com/user-attachments/assets/9260ded1-8e04-42e7-b718-d0b7d70a419d)
